### PR TITLE
Change single quotes for doubles in tracker

### DIFF
--- a/Resources/views/Analytics/async.html.twig
+++ b/Resources/views/Analytics/async.html.twig
@@ -72,9 +72,9 @@ if ( _gaq == null || typeof(_gaq) != 'array') { var _gaq = window._gaq = []; }
         _gaq.push(['{{ google_analytics.trackerName(key) }}_trackPageview', '{{ google_analytics.getCustomPageView() | raw }}']);
     {% else %}
         if (window.location.hash) {
-            _gaq.push(['{{ google_analytics.trackerName(key) }}_trackPageview', '{{ google_analytics.getRequestUri() | raw }}'+window.location.hash]);
+            _gaq.push(['{{ google_analytics.trackerName(key) }}_trackPageview', "{{ google_analytics.getRequestUri() | raw }}"+window.location.hash]);
         } else {
-            _gaq.push(['{{ google_analytics.trackerName(key) }}_trackPageview', '{{ google_analytics.getRequestUri() | raw }}']);
+            _gaq.push(['{{ google_analytics.trackerName(key) }}_trackPageview', "{{ google_analytics.getRequestUri() | raw }}"]);
         }
     {% endif %}
 


### PR DESCRIPTION
This solves a strange problem with IE and Safari, who both seem to
decode %27 (to ') in javascript as it finds it. Meaning that if that
character code appears in a URL, then the ' becomes part of the
javascript syntax, which breaks every other part of the syntax.